### PR TITLE
Removed conformity in the interface of panels for ParametricOctreeDistributedDiscreteModels.jl

### DIFF
--- a/src/Distributed/ParametricOctreeDistributedDiscreteModels.jl
+++ b/src/Distributed/ParametricOctreeDistributedDiscreteModels.jl
@@ -82,7 +82,7 @@ end
 function _create_parametric_octree_dmodel_coarse_model()
   # 6 panels (cells), 4 corners (vertices) each panel
   cell_node_ids = _CCAM_panel_wise_node_ids(NPANELS)
-  node_coordinates = Vector{Point{2,Float64}}(undef,8)
+  node_coordinates = Vector{Point{2,Float64}}(undef,24)
   # These coordinates are junk coordinates, but they have to be unique.
   # This a precondition for the OctreeDistributedDiscreteModel to properly
   # count the vertices of the coarse model

--- a/src/Geometry/cube_surface.jl
+++ b/src/Geometry/cube_surface.jl
@@ -11,7 +11,7 @@ end
 function _CCAM_panel_wise_node_ids(npanels)
   ## CCAM panel ordering
   Dc=2  
-  data = [ 1,2,3,4, 3,4,5,6,  2,7,4,6, 8,5,7,6, 1,8,2,7, 1,3,8,5 ]
+  data = [ 1,2,3,4, 5,6,7,8,  9,10,11,12, 13,14,15,16, 17,18,19,20, 21,22,23,24 ]
   ptr = generate_ptr(Dc,npanels)
   Table(data,ptr)
 end 


### PR DESCRIPTION
WIP 

Warning: this PR seems to break the parametric discrete models written with Gridap/GridapDistributed. 

In particular, when running the Laplace-Beltrami convergence tests, I got the following error:

```
57902] signal (11.128): Segmentation fault
in expression starting at /home/u1134396/git-repos/tamara_geosciences/GridapGeosciences.jl/tests/Laplace/mpi/LaplaceBeltramiTests.jl:9
setindex! at ./array.jl:1021 [inlined]
inverse_table at /home/u1134396/.julia/packages/Gridap/JDFDa/src/Arrays/Tables.jl:307
generate_cells_around at /home/u1134396/.julia/packages/Gridap/JDFDa/src/Geometry/GridTopologies.jl:610 [inlined]
UnstructuredGridTopology at /home/u1134396/.julia/packages/Gridap/JDFDa/src/Geometry/UnstructuredGridTopologies.jl:36
coarse_cube_surface_3D at /home/u1134396/git-repos/tamara_geosciences/GridapGeosciences.jl/src/Geometry/cube_surface.jl:43
coarse_cube_model at /home/u1134396/git-repos/tamara_geosciences/GridapGeosciences.jl/src/Geometry/cube_surface.jl:55 [inlined]
#coarse_parametric_model#14 at /home/u1134396/git-repos/tamara_geosciences/GridapGeosciences.jl/src/Geometry/parametric_model.jl:2 [inlined]
coarse_parametric_model at /home/u1134396/git-repos/tamara_geosciences/GridapGeosciences.jl/src/Geometry/parametric_model.jl:1 [inlined]
get_refined_models at /home/u1134396/git-repos/tamara_geosciences/GridapGeosciences.jl/tests/convergence_tools.jl:60
get_refined_models at /home/u1134396/git-repos/tamara_geosciences/GridapGeosciences.jl/tests/convergence_tools.jl:60 [inlined]
#get_models#9 at /home/u1134396/git-repos/tamara_geosciences/GridapGeosciences.jl/tests/convergence_tools.jl:28
get_models at /home/u1134396/git-repos/tamara_geosciences/GridapGeosciences.jl/tests/convergence_tools.jl:27 [inlined]
#main#44 at /home/u1134396/git-repos/tamara_geosciences/GridapGeosciences.jl/tests/Laplace/LaplaceBeltrami.jl:182
unknown function (ip: 0x719109ac3bd1)
_jl_invoke at /cache/build/builder-amdci5-7/julialang/julia-release-1-dot-10/src/gf.c:2895 [inlined]
ijl_apply_generic at /cache/build/builder-amdci5-7/julialang/julia-release-1-dot-10/src/gf.c:3077
main at /home/u1134396/git-repos/tamara_geosciences/GridapGeosciences.jl/tests/Laplace/LaplaceBeltrami.jl:170
unknown function (ip: 0x719109a922f8)
_jl_invoke at /cache/build/builder-amdci5-7/julialang/julia-release-1-dot-10/src/gf.c:2895 [inlined]
ijl_apply_generic at /cache/build/builder-amdci5-7/julialang/julia-release-1-dot-10/src/gf.c:3077
#1 at /home/u1134396/git-repos/tamara_geosciences/GridapGeosciences.jl/tests/Laplace/mpi/LaplaceBeltramiTests.jl:10
#with_mpi#84 at /home/u1134396/.julia/packages/PartitionedArrays/MVmxR/src/mpi_array.jl:70
unknown function (ip: 0x719109a92173)
_jl_invoke at /cache/build/builder-amdci5-7/julialang/julia-release-1-dot-10/src/gf.c:2895 [inlined]
ijl_apply_generic at /cache/build/builder-amdci5-7/julialang/julia-release-1-dot-10/src/gf.c:3077
with_mpi at /home/u1134396/.julia/packages/PartitionedArrays/MVmxR/src/mpi_array.jl:64
unknown function (ip: 0x719109a8e935)
_jl_invoke at /cache/build/builder-amdci5-7/julialang/julia-release-1-dot-10/src/gf.c:2895 [inlined]
ijl_apply_generic at /cache/build/builder-amdci5-7/julialang/julia-release-1-dot-10/src/gf.c:3077
jl_apply at /cache/build/builder-amdci5-7/julialang/julia-release-1-dot-10/src/julia.h:1982 [inlined]
do_call at /cache/build/builder-amdci5-7/julialang/julia-release-1-dot-10/src/interpreter.c:126
eval_value at /cache/build/builder-amdci5-7/julialang/julia-release-1-dot-10/src/interpreter.c:223
eval_stmt_value at /cache/build/builder-amdci5-7/julialang/julia-release-1-dot-10/src/interpreter.c:174 [inlined]
eval_body at /cache/build/builder-amdci5-7/julialang/julia-release-1-dot-10/src/interpreter.c:617
jl_interpret_toplevel_thunk at /cache/build/builder-amdci5-7/julialang/julia-release-1-dot-10/src/interpreter.c:775
jl_toplevel_eval_flex at /cache/build/builder-amdci5-7/julialang/julia-release-1-dot-10/src/toplevel.c:934
jl_toplevel_eval_flex at /cache/build/builder-amdci5-7/julialang/julia-release-1-dot-10/src/toplevel.c:877
ijl_toplevel_eval_in at /cache/build/builder-amdci5-7/julialang/julia-release-1-dot-10/src/toplevel.c:985
eval at ./boot.jl:385 [inlined]
include_string at ./loading.jl:2146
_jl_invoke at /cache/build/builder-amdci5-7/julialang/julia-release-1-dot-10/src/gf.c:2895 [inlined]
ijl_apply_generic at /cache/build/builder-amdci5-7/julialang/julia-release-1-dot-10/src/gf.c:3077
_include at ./loading.jl:2206
include at ./Base.jl:495
jfptr_include_46653.1 at /home/u1134396/.julia/juliaup/julia-1.10.10+0.x64.linux.gnu/lib/julia/sys.so (unknown line)
_jl_invoke at /cache/build/builder-amdci5-7/julialang/julia-release-1-dot-10/src/gf.c:2895 [inlined]
ijl_apply_generic at /cache/build/builder-amdci5-7/julialang/julia-release-1-dot-10/src/gf.c:3077
exec_options at ./client.jl:323
_start at ./client.jl:557
jfptr__start_83114.1 at /home/u1134396/.julia/juliaup/julia-1.10.10+0.x64.linux.gnu/lib/julia/sys.so (unknown line)
_jl_invoke at /cache/build/builder-amdci5-7/julialang/julia-release-1-dot-10/src/gf.c:2895 [inlined]
ijl_apply_generic at /cache/build/builder-amdci5-7/julialang/julia-release-1-dot-10/src/gf.c:3077
jl_apply at /cache/build/builder-amdci5-7/julialang/julia-release-1-dot-10/src/julia.h:1982 [inlined]
true_main at /cache/build/builder-amdci5-7/julialang/julia-release-1-dot-10/src/jlapi.c:582
jl_repl_entrypoint at /cache/build/builder-amdci5-7/julialang/julia-release-1-dot-10/src/jlapi.c:731
main at /cache/build/builder-amdci5-7/julialang/julia-release-1-dot-10/cli/loader_exe.c:58
unknown function (ip: 0x71910aa29d8f)
__libc_start_main at /lib/x86_64-linux-gnu/libc.so.6 (unknown line)
unknown function (ip: 0x4010b8)
Allocations: 16695501 (Pool: 16684551; Big: 10950); GC: 23
Segmentation fault (core dumped)
```